### PR TITLE
Corrected SE miscalculation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ BugReports: https://github.com/morrowcj/remotePARTS/issues
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: TRUE
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.2
 Depends: R (>= 4.0)
 Imports: 
   stats,

--- a/R/AR_reml.R
+++ b/R/AR_reml.R
@@ -221,21 +221,21 @@ AR_fun <- function(par, y, X, logLik.only = TRUE) {
 
     # important stats
     MSE <- as.numeric(s2) #MSE
-    s2beta <- MSE * solve(t(X) %*% iV %*% X) #SE
+    s2beta <- MSE * solve(t(X) %*% iV %*% X) #Variance
     t.stat = (abs(beta) / diag(s2beta)^0.5)
     pval = 2 * stats::pt(q = t.stat, df = n.obs - q,
                          lower.tail = FALSE )
 
     yhat = X %*% beta
 
-    # log likelihood without constants (i.e. s2) - no parameter dependancy
+    # log likelihood without constants (i.e. s2) - no parameter dependency
     logLik <- 0.5 * (n.obs - q) * log(2 * pi) +
       determinant(t(X) %*% X)$modulus[1] - logLik
 
     # collect output
     out.list <- list(call = call,
                      coefficients = beta[, 1],
-                     SE = diag(s2beta),
+                     SE = diag(s2beta)^0.5, # standard error
                      tstat = t.stat[, 1],
                      pval = pval[, 1],
                      MSE = MSE,

--- a/R/fitGLS_partitionMC.R
+++ b/R/fitGLS_partitionMC.R
@@ -2,8 +2,6 @@
 #'
 #' @rdname partGLS
 #'
-#' @return
-#'
 #' @examples
 #' \dontrun{
 #' ## read data

--- a/R/spatial-functions.R
+++ b/R/spatial-functions.R
@@ -123,7 +123,7 @@ covar_taper <- function(d, theta, cor = NULL){
 #'
 #' \code{v = exp(-d/range)}
 #'
-#' @return
+#' @return the exponential covariance (v)
 #'
 #' @examples
 #'
@@ -156,7 +156,7 @@ covar_exp <- function(d, range){
 #' Note that \code{covar_exppow(..., shape = 1)} is equivalent to
 #' \code{covar_exp()} but is needed as a separate function for use with \code{fitCor}.
 #'
-#' @return
+#' @return exponential-power covariance (v)
 #'
 #' @examples
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,18 @@
 ## R CMD check results
+
 There were no ERRORs or WARNINGs.
 
-There was 1 NOTE: 
+There was 1 NOTE associated with the first-time submission: 
 
-  * "Maintainer: 'Clay Morrow <morrowcj@outlook.com>'"
+```
+  Maintainer: 'Clay Morrow <morrowcj@outlook.com>'
 
-  This is a first-time submission.
-  
+  New submission
+```
+
 ### Test Environments
-This version of the package was tested, using github actions, with the code
+
+This version of the package was tested, using github actions, with the following call to `rcmdcheck` on 2022-06-30:
 
 ```
 rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
@@ -22,34 +26,30 @@ Checks were conducted on the following systems:
   
   * ubuntu-20.04 (release)
   
-Additionally, the package was tested on the development version of R for Windows 
-(on 2022-03-01) with 
-
-```
-devtools::check_win_devel()
-```
-
-*R-devel results here*
+Additionally, the package was checked on the development version of R for Windows 
+(on 2022-06-30) with `devtools::check_win_devel()` and the same results as above
+were returned. 
 
 ## Downstream dependencies
+
 There are currently no downstream dependencies for this package.
 
 ## Other Comments
-
-* Some users have had trouble building the vignette on personal machines 
-(using `devtools::install_github()`), but I have not had any trouble on any 
-of the systems I have personally tested on. 
-
-* Some examples in `partGLS.Rd` and `fitGLS_opt.Rd` can take a bit longer to run
-(10-20 seconds total) since the functions documented in these files need to 
-invert multiple large matrices. 
 
 * On the ubuntu-20.04 (release) system, an additional NOTE occurred, indicating
 that the libraries are much larger than on the other the systems:
 
 ```
   ❯ checking installed package size ... NOTE
-    installed size is 32.5Mb
+    installed size is 32.7Mb
     sub-directories of 1Mb or more:
-      libs  31.0Mb
+      libs  31.3Mb
 ```
+
+* Some users have had trouble building the vignette on personal machines 
+(using `devtools::install_github()`), but I have not had any trouble on any 
+of the systems I have personally tested with. 
+
+* Some examples in `partGLS.Rd` and `fitGLS_opt.Rd` can take a bit longer to run
+(10-20 seconds total) since the functions documented in these files need to 
+invert multiple large matrices. 

--- a/man/covar_functions.Rd
+++ b/man/covar_functions.Rd
@@ -27,9 +27,9 @@ subtracted from \code{cor}.}
 \value{
 a tapered-spherical transformation of d is returned.
 
+the exponential covariance (v)
 
-
-
+exponential-power covariance (v)
 }
 \description{
 Tapered-spherical distance-based covariance function

--- a/man/partGLS.Rd
+++ b/man/partGLS.Rd
@@ -115,8 +115,6 @@ more information}
 \item{file}{a text string indicating the csv file from which to read data}
 }
 \value{
-
-
 \code{fitGLS_partition} returns a list object of class "partGLS" which
 contains at least the following elements:
 

--- a/man/remotePARTS-package.Rd
+++ b/man/remotePARTS-package.Rd
@@ -6,7 +6,7 @@
 \alias{remotePARTS-package}
 \title{remotePARTS: Spatiotemporal Autoregression Analyses for Large Data Sets}
 \description{
-These tools were created to test map-scale hypotheses about trends in large remotely sensed data sets but any data with spatial and temporal variation can be analyzed. Tests are conducted using the PARTS method for analyzing spatially autocorrelated time series (Ives et al., 2021: <doi:10.1016/j.rse.2021.112678>). The method's unique approach can handle extremely large data sets that other spatiotemporal models cannot, while still appropriately accounting for spatial and temporal autocorrelation. This is done by partitioning the data into smaller chunks, analyzing chunks separately and then combining the separate analyses into a single, correlated test of the map-scale hypotheses.
+These tools were created to test map-scale hypotheses about trends in large remotely sensed data sets but any data with spatial and temporal variation can be analyzed. Tests are conducted using the PARTS method for analyzing spatially autocorrelated time series (Ives et al., 2021: \doi{10.1016/j.rse.2021.112678}). The method's unique approach can handle extremely large data sets that other spatiotemporal models cannot, while still appropriately accounting for spatial and temporal autocorrelation. This is done by partitioning the data into smaller chunks, analyzing chunks separately and then combining the separate analyses into a single, correlated test of the map-scale hypotheses.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
This PR addresses Issue #2 wherein the variance of the AR REML model was erroneously reported as SE. 

It also makes a few small changes to the documentation and updates `cran-comments.md` with newer information to provide when submitting to CRAN.